### PR TITLE
Temporary fix so portfolio images look okay on Safari

### DIFF
--- a/_sass/_portfolio.scss
+++ b/_sass/_portfolio.scss
@@ -1,15 +1,16 @@
 /* Style the Image Used to Trigger the Modal */
 .bow-img {
-  margin: 0.8rem;
   cursor: pointer;
   transition: 0.3s;
-  //width: 100%;
-  max-width: 32vw;
+  min-width: 50%;
+  max-height: 26vh;
+  margin: 0.8rem;
+  width: 50%;
 }
 
 @media (max-width: 767px) {
   .bow-img {
-    max-width: 88vw;
+    width: 88%;
   }
 }
 
@@ -96,6 +97,8 @@
 .bow-images {
   display: flex;
   justify-content: center;
+  align-items: center;
+  width: 100%;
 }
 
 // mobile: @media (max-width: 767px)


### PR DESCRIPTION
Portfolio images were stretched on Safari. This is not perfect because the images don't necessarily have the same height but good enough for now.